### PR TITLE
Add primary key to lock table

### DIFF
--- a/sql/ensure-migrations-tables.sql
+++ b/sql/ensure-migrations-tables.sql
@@ -8,5 +8,6 @@ CREATE TABLE IF NOT EXISTS migrations (
 );
 
 CREATE TABLE IF NOT EXISTS migrations_lock (
-    empty_table BOOLEAN
+    empty_table BOOLEAN,
+    PRIMARY KEY (empty_table)
 );


### PR DESCRIPTION
Hello,
thanks for providing this valuable tool.

While using it in a clustered MySQL deployment running in K8S i've found out that tables without a primary key cause the checks over the InnoDB cluster to fail, not allowing the cluster to restart.

Making the empy_table column a PK solves the issues, as the table is used just for locks it shouldn't cause any unwanted side effect, tests are passing.